### PR TITLE
Fix DB path in bot router

### DIFF
--- a/routes/bot-router.js
+++ b/routes/bot-router.js
@@ -3,7 +3,8 @@
 
 const express = require('express');
 const path = require('path');
-const db = require('./db/mysql');
+// Usamos la ruta correcta al módulo de base de datos
+const db = require('../db/mysql');
 
 // Crear un router de Express
 const botRouter = express.Router();


### PR DESCRIPTION
## Summary
- fix incorrect require path for database module in `routes/bot-router.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840894c266c832cbbd93c196885e600